### PR TITLE
fix: enhance getRecordTitle to handle missing or non-scalar label fields

### DIFF
--- a/Classes/Service/DatabaseService.php
+++ b/Classes/Service/DatabaseService.php
@@ -453,7 +453,7 @@ class DatabaseService
     /**
      * @param mixed[] $row
      */
-    private function getRecordTitle(string $tableName, array $row): ?string
+    private function getRecordTitle(string $tableName, array $row): string
     {
         $labelField = $GLOBALS['TCA'][$tableName]['ctrl']['label'] ?? null;
         return isset($row[$labelField]) && is_scalar($row[$labelField])

--- a/Classes/Service/DatabaseService.php
+++ b/Classes/Service/DatabaseService.php
@@ -455,8 +455,10 @@ class DatabaseService
      */
     private function getRecordTitle(string $tableName, array $row): ?string
     {
-        $labelField = $GLOBALS['TCA'][$tableName]['ctrl']['label'];
-        return $row[$labelField];
+        $labelField = $GLOBALS['TCA'][$tableName]['ctrl']['label'] ?? null;
+        return isset($row[$labelField]) && is_scalar($row[$labelField])
+        ? (string)$row[$labelField]
+        : '[No title]';
     }
 
     private function getBackendUser(): ?BackendUserAuthentication


### PR DESCRIPTION
This pull request updates the `getRecordTitle` method in `Classes/Service/DatabaseService.php` to improve error handling and ensure a fallback value is provided when the expected title field is not available or valid.

Error handling and fallback improvements:

* [`Classes/Service/DatabaseService.php`](diffhunk://#diff-1d175427e14e1a5794196c85342ba61f2df99975faddad6f141629936aae5da3L458-R461): Modified the `getRecordTitle` method to handle cases where the `label` field is not set or is not a scalar value. The method now uses a fallback value of `[No title]` when the title cannot be determined.