### PR TITLE
feat: pass settings to EnrichDetailResultEvent dispatch

### DIFF
--- a/Classes/Controller/AbstractExtbaseController.php
+++ b/Classes/Controller/AbstractExtbaseController.php
@@ -206,7 +206,7 @@ abstract class AbstractExtbaseController extends ActionController
 
         /** @var EnrichDetailResultEvent $enrichDetailResultEvent */
         $enrichDetailResultEvent = $this->eventDispatcher->dispatch(
-            new EnrichDetailResultEvent($this->extensionName, $result)
+            new EnrichDetailResultEvent($this->extensionName, $result, $this->settings)
         );
 
         $result = $enrichDetailResultEvent->getDetailResult();

--- a/Classes/Event/EnrichDetailResultEvent.php
+++ b/Classes/Event/EnrichDetailResultEvent.php
@@ -10,12 +10,22 @@ final class EnrichDetailResultEvent extends AbstractExtbaseEvent
 {
     private DetailResult $detailResult;
 
+    /**
+     * @var mixed[]
+     */
+    private array $settings;
+
+    /**
+     * @param mixed[] $settings
+     */
     public function __construct(
         string $extensionName,
         DetailResult $detailResult,
+        array $settings,
     ) {
         parent::__construct($extensionName);
         $this->detailResult = $detailResult;
+        $this->settings = $settings;
     }
 
     public function setAdditionalData(mixed $additionalData): self
@@ -28,5 +38,23 @@ final class EnrichDetailResultEvent extends AbstractExtbaseEvent
     public function getDetailResult(): DetailResult
     {
         return $this->detailResult;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getSettings(): array
+    {
+        return $this->settings;
+    }
+
+    /**
+     * @param mixed[] $settings
+     */
+    public function setSettings(array $settings): self
+    {
+        $this->settings = $settings;
+
+        return $this;
     }
 }


### PR DESCRIPTION
Add `$this->settings` as third argument when dispatching EnrichDetailResultEvent to provide additional configuration context during result enrichment.